### PR TITLE
Added config item `protocol`.

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -2,6 +2,7 @@ server: # your mediawiki server
   "ja.wikipedia.org"
 path: #your api.php path
   "/w"
+protocol: http  # http or https
 username: # your username
 password: # your password
 namespaces: # namespace id and prefix to process

--- a/main.js
+++ b/main.js
@@ -10,8 +10,9 @@ const util = require('util');
 
 /*** mediawiki API bot ***/
 const bot = new nodemw({
-  server : config.server,
-  path   : config.path,
+  protocol : config.protocol,
+  server   : config.server,
+  path     : config.path,
 });
 
 module.exports = main;


### PR DESCRIPTION
Added config item `protocol`. ( default setting : http )

(in Japanese)
常時SSL化された Mediawiki サイトに接続するために　プロトコルの設定項目( デフォルト値： http )を追加しました。
